### PR TITLE
Update about page

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,26 +1,75 @@
 ---
 layout: about
-title: about
+title: Home
 permalink: /
-#subtitle: <a href='#'>Affiliations</a>. Address. Contacts. Moto. Etc.
-
-#profile:
-#  align: right
-#  image: prof_pic.jpg
-#  image_circular: false # crops the image to make it circular
-#  address: >
-#    <p>555 your office number</p>
-#    <p>123 your address street</p>
-#    <p>Your City, State 12345</p>
-
 news: false  # includes a list of news items
-latest_posts: true  # includes a list of the newest posts
+latest_posts: false  # includes a list of the newest posts
 selected_papers: false # includes a list of papers marked as "selected={true}"
 social: true  # includes social icons at the bottom of the page
 ---
 
-The Catalyst Project is looking for organisations in Africa and Latin America to partner with and create a collaborative cloud infrastructure service. We want to enable community-based interactive cloud-native workflow(s) in the Biomedical, Health, and Public Health Sciences. We want to learn how this model could be extended to other global communities historically marginalised from large-scale scientific infrastructure projects. This is a collaborative effort between six leading organizations in open infrastructure, community, and global leadership: <a href ='https://2i2c.org/'>2i2c</a>, <a  href ='https://carpentries.org/index.html'> The Carpentries </a>,<a href ='https://www.cscce.org/'> CSCCE </a>,<a href ='https://investinopen.org/'> Invest in Open Infrastructure </a>, <a href ='https://www.metadocencia.org/'> MetaDocencia </a>, and <a href ='https://openlifesci.org/'> Open Life Science </a>.
+The Catalyst Project is looking for organisations in Africa and Latin America
+to partner with and create a collaborative cloud infrastructure service.
+We want to enable community-based interactive cloud-native workflow(s)
+in the Biomedical, Health, and Public Health Sciences.
+We want to learn how this model could be extended to other global communities
+historically marginalised from large-scale scientific infrastructure projects.
 
-Your community can participate in different ways: using a cloud hub set up for your specific needs and collaboratively managing it; taking training on cloud usage, open leadership, and community engagement; helping us build our governance model.
+## Get Involved!
 
+Your community can participate in different ways:
+using a cloud hub set up for your specific needs and collaboratively managing it;
+taking training on cloud usage, open leadership, and community engagement;
+helping us build our governance model.
 
+If you would like to get involved, or if you have questions about the project,
+please [contact us]({{ site.email }})!
+
+## Project Outputs
+
+Reflecting a commitment to openness shared among the project partners,
+we are publishing public versions of documents and other artifacts
+produced as the Catalyst Project proceeds.
+Visit [our Zenodo community](https://zenodo.org/communities/catalyst-project/) to explore the outputs published from the project so far.
+
+## Partner Projects
+
+The Catalyst Project is a collaborative effort between six leading organizations in open infrastructure, community, and global leadership:
+
+### 2i2c
+[2i2c](https://2i2c.org/)’s mission is to make research and education
+more impactful, accessible, and delightful
+by developing, operating, and supporting infrastructure for interactive computing.
+
+### The Carpentries
+[The Carpentries](https://carpentries.org/) build global capacity
+in essential data and computational skills
+for conducting efficient, open, and reproducible research,
+through training, community building, and curriculum development.
+
+### CSCCE
+[The Center for Scientific Collaboration and Community Engagement (CSCCE)](https://www.cscce.org/)
+is a training and research center to support and study the emerging field of
+scientific community engagement.
+
+### IOI
+[Invest in Open Infrastructure (IOI)](http://investinopen.org)
+is an initiative dedicated to improving funding and resourcing
+for open technologies and systems supporting research and scholarship.
+They do this by shedding light on challenges,
+conducting research, and working with decision makers to enact change.
+
+### MetaDocencia
+[MetaDocencia](http://metadocencia.org)’s mission is
+to advance innovation with a local perspective
+that responsibly builds scientific and technical capacities
+through the co-creation of networks, learning spaces,
+and accessible resources for Spanish-speaking communities.
+
+### OLS
+[Open Life Science (OLS)](https://openlifesci.org/) is
+an open science capacity building organization
+with a mission to upskill, connect and support a distributed network of ambassadors
+enabling the adoption of open science principles in their local communities.
+
+OLS hosts the Catalyst Project manager, Tajuddeen Gwadabe.


### PR DESCRIPTION
Closes #3 by updating the About page (which is the landing page).

- renames the page to _Home_
- introduces some section headings
- adds a link to the Zenodo community
- includes more details about each project partner org