### PR TITLE
Use Title Case for blog homepage

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: blog
+title: Blog
 pagination:
   enabled: true
   collection: posts


### PR DESCRIPTION
Use Title Case for on the title of the main blog listing, to be consistent with the newly-renamed _Home_ page.